### PR TITLE
Added CBMicroBit, for piping Microbit -> OSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Inspired by the [Awesome lists](https://github.com/sindresorhus/awesome).
 - [App Inventor + IoT](http://iot.appinventor.mit.edu/#/microbit/microbitintro) - Control a micro:bit via Bluetooth with App Inventor, a visual programming environment for Android applications.
 - [BlockyTalkyBLE](http://www.playfulcomputation.group/blockytalkyble.html) - MakeCode and App Inventor extension that makes it easy to connect AppInventor mobile phone apps with the BBC micro:bit wirelessly over Bluetooth.
 - [DroidScript - MicroBit Plugin](https://play.google.com/store/apps/details?id=org.droidscript.microbit) - Allows you you to control the BBC micro:bit remotely from your own DroidScript apps (Android apps written in JavaScript).
+- [CBMicroBit](https://github.com/Louismac/CBMicroBit) - A CoreBluetooth wrapper that connects a Micro:Bit to a computer running OSX using BLE and outputs over OSC (standalone, C++ and Objective C libraries)
 
 
 ## Programming Tools

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Inspired by the [Awesome lists](https://github.com/sindresorhus/awesome).
 - [App Inventor + IoT](http://iot.appinventor.mit.edu/#/microbit/microbitintro) - Control a micro:bit via Bluetooth with App Inventor, a visual programming environment for Android applications.
 - [BlockyTalkyBLE](http://www.playfulcomputation.group/blockytalkyble.html) - MakeCode and App Inventor extension that makes it easy to connect AppInventor mobile phone apps with the BBC micro:bit wirelessly over Bluetooth.
 - [DroidScript - MicroBit Plugin](https://play.google.com/store/apps/details?id=org.droidscript.microbit) - Allows you you to control the BBC micro:bit remotely from your own DroidScript apps (Android apps written in JavaScript).
-- [CBMicroBit](https://github.com/Louismac/CBMicroBit) - A CoreBluetooth wrapper that connects a Micro:Bit to a computer running OSX using BLE and outputs over OSC (standalone, C++ and Objective C libraries)
+- [CBMicroBit](https://github.com/Louismac/CBMicroBit) - A CoreBluetooth wrapper that connects a micro:bit to a computer running OSX using BLE and outputs over OSC (standalone, C++ and Objective C libraries).
 
 
 ## Programming Tools


### PR DESCRIPTION
Wrapper round CoreBluetooth to easily get Micro:Bit button and accelerometer data into applications running on OSX that accept OSC (e.g. Max/MSP, Supercollider, Processing)