### PR TITLE
Add MakerBit to MakeCode Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The following packages can be added into MakeCode by copying the GitHub URL and 
 - [HoneyBit](https://github.com/HoneycombKits/pxt-HoneyBit) - A Honeycomb kits package for micro:bit MakeCode.
 - [Bluetooth beacons](https://github.com/kshoji/pxt-bluetooth-beacons) - Allows the micro:bit to act as iBeacon / AltBeacon advertiser.
 - [LumexOLED](https://github.com/lioujj/pxt-oled) - Package designed for Lumex OLED display.
+- [MakerBit](https://github.com/1010Technologies/pxt-makerbit) - Blocks that support Roger Wagner's MakerBit board including Serial MP3, I2C LCD 1602, and ultrasonic.
 
 ##### Node.js Libraries
 


### PR DESCRIPTION
### Resource description

A MakeCode package with blocks that support Roger Wagner's MakerBit board including Serial MP3, I2C LCD 1602, and ultrasonic.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
