### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ All these projects contain steps and resources required for reproduction.
 - [OpenGestureControl](https://opengesturecontrol.github.io) - A Linux application which interacts with the BBC micro:bit to give hand prothesis users the ability to control their desktop computer using gestures.
 - [micro:bit spectrum](https://github.com/linker3000/micro-bit_spectrum) - Circuit and code to display an audio spectrum bar chart on the BBC micro:bit.
 - [micro:bit TVPong](https://github.com/linker3000/Microbit-TVPong) - Play the classic Pong game on a TV - using BBC Microbits as paddles, Bluetooth also supported.
+- [Remote control LibreOffice slides with a micro:bit](https://blog.oless.xyz/post/microbitremote/) - Control LibreOffice Impress slides (as well as any other program) via Bluetooth on Linux.
 
 ### Project Collections
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Useful Articles for developing on the micro:bit.
 - [micro:bit Radio Packets](https://ukbaz.github.io/howto/ubit_radio.html) - Explanation of the MakeCode radio packet specification (built on top of the micro:bit runtime specification) and how to communicate between MakeCode and MicroPython programs via radio.
 - [Synchronized Music on micro:bits](https://blog.flowblok.id.au/2018-02/synchronized-music-on-microbits.html) - Building a micro:bit mesh network so they can play music synchronized across a large area.
 - [Using the Built-in Sensors](https://learn.adafruit.com/micro-bit-lesson-1-using-the-built-in-sensors) - Learn how to use the micro:bit's built-in accelerometer and magnetometer.
+- [Read micro:bit data from Linux via Bluetooth (BLE)] - Random notes and examples about micro:bit BLE and Linux. 
 
 ### Article Collections
 


### PR DESCRIPTION
- [Remote control LibreOffice slides with a micro:bit](https://blog.oless.xyz/post/microbitremote/) - Control LibreOffice Impress slides (as well as any other program) via Bluetooth on Linux.


<!-- Thank you for submitting a new resource to this list! -->

### Resource description

Control LibreOffice Impress slides (as well as any other program) via Bluetooth on Linux, by simulating arrow keys to go forward or back between slides. On Linux the program used to simulate key presses is evemu.

<!-- Please include a short description of the link here -->


### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
