### PR TITLE
Add 'BLE remote control for Spotify' to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ All these projects contain steps and resources required for reproduction.
 - [OpenGestureControl](https://opengesturecontrol.github.io) - A Linux application which interacts with the BBC micro:bit to give hand prothesis users the ability to control their desktop computer using gestures.
 - [micro:bit spectrum](https://github.com/linker3000/micro-bit_spectrum) - Circuit and code to display an audio spectrum bar chart on the BBC micro:bit.
 - [micro:bit TVPong](https://github.com/linker3000/Microbit-TVPong) - Play the classic Pong game on a TV - using BBC Microbits as paddles, Bluetooth also supported.
+- [Bluetooth Low Energy Remote Control for Spotify](https://www.hackster.io/josejuansanchez/bluetooth-low-energy-remote-control-for-spotify-3438d1) - This project allows you to configure your micro:bit to work as a Bluetooth Low Energy remote control for Spotify on macOS.
 
 ### Project Collections
 


### PR DESCRIPTION
### Resource description

A link to a project that allows you to configure your micro:bit to work as a Bluetooth Low Energy remote control for Spotify on macOS.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
