### PR TITLE
Add s2microbit BLE to Scratch 2 Extensions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following editors are no longer maintained:
 - [Scratch for BBC micro:bit](http://www.picaxe.com/BBC-microbit) - Using micro:bit with Scratch / S2Bot as a Bluetooth 'games controller' (needs specific BLED112 Bluetooth dongle).
 - [ScratchX micro:bit extension](https://llk.github.io/microbit-extension/) - Lets you control your micro:bit wirelessly using Scratch programming blocks.
 - [s2m](https://github.com/MrYsLab/s2m) - A Python program that acts as a bridge between the Scratch 2 off-line editor and the micro:bit via USB.
+- [s2microbit BLE](https://github.com/memakura/s2microbit-ble#English) - Scratch 2 (offline) extension for BBC micro:bit bluetooth connection with a Windows PC.
 
 ### Python
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

Scratch 2 (offline) extension for BBC micro:bit bluetooth connection with a Windows PC.


### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
