### PR TITLE
Add NeoBit to Hardware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ The USB Interface Chip is the microcontroller placed close to the battery connec
 - [SparkFun moto:bit](https://github.com/sparkfun/Micro_Bit_Moto_Bit) - Open source files for the SparkFun moto:bit, a board to provide a robotics platform.
 - [SparkFun weather:bit](https://github.com/sparkfun/Micro_Bit_Weather_Bit) - Open source files for the SparkFun weather:bit, a board to provide a weather station.
 - [SparkFun gamer:bit](https://github.com/sparkfun/Micro_Bit_Gamer_Bit) - Open source files for the SparkFun gamer:bit, a board to provide a game system.
+- [NeoBit](https://github.com/ppelleti/NeoBit) - Open source board that lets you hook up NeoPixel and DotStar LEDs to a BBC micro:bit, also contains a headphone jack and a couple of slide potentiometers for input. 
 
 
 ## 3D Printing


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

Adding NeoBit, an open source board that lets you hook up NeoPixel and DotStar LEDs to a BBC micro:bit, also contains a headphone jack and a couple of slide potentiometers for input. 


### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
