### PR TITLE
Add MakeCode extension MakerBit-Touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 - [VL53L0X](https://github.com/Tinkertanker/pxt-range-vl53l0x) - Package to calculate distances using a VL53L0X Time-of-Flight ranging sensor.
 - [KY-040](https://github.com/Tinkertanker/pxt-rotary-encoder-ky040) - Package for using the KY-040 rotary encoder.
 - [PCA9685](https://github.com/Tinkertanker/uDriver_PCA9585) - Package to control the PCA9685, a 16-channel PWM controller, with included servo support.
+- [MakerBit-Touch](https://github.com/1010Technologies/pxt-makerbit-touch) - Touch sensing package for the capacitive touch sensor controller MPR121.
 
 ##### Node.js Libraries
 


### PR DESCRIPTION

### Resource description

Touch sensing with the capacitive touch sensor controller MPR121 (while it belongs to the MakerBit family the packages works independently of a MakerBit board)


### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

- [X] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [X] I am making an individual pull request for each suggestion
- [X] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [X] The content linked is in English, or it contains an English translation
- [X] I have added the new entry to the bottom of its the category
- [X] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
