### PR TITLE
Add MAX7219 8x8 MakeCode Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 - [KY-040](https://github.com/Tinkertanker/pxt-rotary-encoder-ky040) - Package for using the KY-040 rotary encoder.
 - [PCA9685](https://github.com/Tinkertanker/uDriver_PCA9585) - Package to control the PCA9685, a 16-channel PWM controller, with included servo support.
 - [MakerBit-Touch](https://github.com/1010Technologies/pxt-makerbit-touch) - Touch sensing package for the capacitive touch sensor controller MPR121.
-- [MAX7219 8x8](https://github.com/alankrantas/pxt-MAX7219_8x8) - Control the MAX7219 LED matrix display modules with an 8x8 LED matrix.
+- [MAX7219 8x8](https://github.com/alankrantas/pxt-MAX7219_8x8) - Control the MAX7219 LED matrix display module with an 8x8 LED matrix.
 
 ##### Node.js Libraries
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 - [KY-040](https://github.com/Tinkertanker/pxt-rotary-encoder-ky040) - Package for using the KY-040 rotary encoder.
 - [PCA9685](https://github.com/Tinkertanker/uDriver_PCA9585) - Package to control the PCA9685, a 16-channel PWM controller, with included servo support.
 - [MakerBit-Touch](https://github.com/1010Technologies/pxt-makerbit-touch) - Touch sensing package for the capacitive touch sensor controller MPR121.
+- [MAX7219 8x8](https://github.com/alankrantas/pxt-MAX7219_8x8) - Control the MAX7219 LED matrix display modules with an 8x8 LED matrix.
 
 ##### Node.js Libraries
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

Control the MAX7219 LED matrix display module with an 8x8 LED matrix.


### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
