### PR TITLE
Add PCA9685 to MakeCode packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 - [MAX7219 8x8](https://github.com/alankrantas/pxt-MAX7219_8x8) - Control the MAX7219 LED matrix display module with an 8x8 LED matrix.
 - [ColorBit](https://github.com/51bit/colorbit) - 5x5 WS2812B LED matrix makecode extension for micro:bit.
 - [dfplayer](https://github.com/lioujj/pxt-mp3) - Play mp3 files with a DFPlayer mini module.
+- [PCA9685](https://github.com/jdarling/pxt-pca9685) - Generic PCA9685 driver, a 16-channel PWM controller.
 
 ##### Node.js Libraries
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
Generic PCA9685 driver, a 16-channel PWM controller. 

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
