### PR TITLE
Add Micropython-MakeCode compatible Radio to MicroPython modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The following editors are no longer maintained:
 - [Kitronik Motor Driver Board](https://github.com/MrYsLab/kitronik_motor_board) - Class to control the Kitronik motor driver board.
 - [microbit python libs](https://github.com/shaoziyang/microbit-lib) - Growing collection of modules, including TM1637/TM1650 7-seg LEDs, OLED 128x64, LCD1602, AT24XX EEPROM, DS1302/DS1307/DS3231 RTC, NeoPixel drivers, APDS9930 Digital Proximity and Ambient Light Sensor, BME280 humidity and pressure sensor, BMP280/BMP180 pressure sensors.
 - [RAK811](https://github.com/PiSupply/rak811-python) - RAK811 Python library for use with LoRa pHAT & MicroBIT Node.
+- [Micropython-MakeCode compatible Radio](https://github.com/rhubarbdog/microbit-radio) - Class MakeRadio which includes all the functionality of the Micropyhton radio module, while being compatible with MakeCode blocks.
 
 ##### Python Libraries
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[Micropython-MakeCode compatible Radio](https://github.com/rhubarbdog/microbit-radio) - Class MakeRadio which includes all the functionality of the Micropyhton radio module, while being compatible with MakeCode blocks

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
