### PR TITLE
Add SFC SNES Gamepad to MakeCode Extensions section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 - [MLX90614](https://github.com/DoraLC/pxt-MLX90614) - I2C driver for Infra Red Thermometer MLX90614.
 - [Adafruit Motor Driver Board](https://github.com/vijairaj/pxt-adafruit-motor-driver) - Driver to control the DC motors on the Adafruit Motor Shield v1.
 - [ESP-01](https://github.com/51bit/esp01) - Control an ESP8266 module via serial AT commands.
+- [SFC SNES Gamepad](https://github.com/51bit/SFC) - Connect an SNES (Super Nintendo/Super Famicom) controller to the micro:bit.
 
 ##### Node.js and Browser Libraries
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[SFC SNES Gamepad](https://github.com/51bit/SFC) - Connect an SNES (Super Nintendo/Super Famicom) controller to the micro:bit.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
