### PR TITLE
Add clarification for readme regarding Espruino

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Contributions are welcome! Not sure how to submit a contribution? Have a look at
 - [MakeCode](https://makecode.microbit.org) - This block and text editor for the micro:bit provides an in-browser emulator, a Blocks interface, and JavaScript (TypeScript) editor.
 	- [MakeCode Beta](https://makecode.microbit.org/beta) - Beta version of the MakeCode editor to test the latest features.
 	- [MakeCode Windows 10 App](https://www.microsoft.com/store/apps/9pjc7sv48lcx) - Windows 10 application for micro:bit MakeCode.
-- [Espruino JavaScript](https://www.espruino.com/MicroBit) - JavaScript interpreter for microcontrollers. It also offers a WebIDE for written code and blocks. Check your micro:bit if it has a combined sensor or two individual sensors - the former doesn't work.
+- [Espruino JavaScript](https://www.espruino.com/MicroBit) - JavaScript interpreter for microcontrollers. It also offers a WebIDE for written code and blocks. It's currently not compatible with v1.5 of the micro:bit (due to the different motion sensors).
 
 ##### 🗿 MakeCode Extensions
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Contributions are welcome! Not sure how to submit a contribution? Have a look at
 - [MakeCode](https://makecode.microbit.org) - This block and text editor for the micro:bit provides an in-browser emulator, a Blocks interface, and JavaScript (TypeScript) editor.
 	- [MakeCode Beta](https://makecode.microbit.org/beta) - Beta version of the MakeCode editor to test the latest features.
 	- [MakeCode Windows 10 App](https://www.microsoft.com/store/apps/9pjc7sv48lcx) - Windows 10 application for micro:bit MakeCode.
-- [Espruino JavaScript](https://www.espruino.com/MicroBit) - JavaScript interpreter for microcontrollers. It also offers a WebIDE for written code and blocks.
+- [Espruino JavaScript](https://www.espruino.com/MicroBit) - JavaScript interpreter for microcontrollers. It also offers a WebIDE for written code and blocks. Check your micro:bit if it has a combined sensor or two individual sensors - the former doesn't work.
 
 ##### 🗿 MakeCode Extensions
 


### PR DESCRIPTION
Add clarification for Espruino as I tried using Espruino on my v1.5 micro:bit but Espruino doesn't work with the LSM303AGR on the v1.5 micro:bit due to different I2C addresses. I [added an issue](https://github.com/espruino/EspruinoDocs/issues/537) however @gfwilliams hasn't fixed this due to low interest from the entire micro:bit community - I'll try and make a PR for the Micro:bit Educational Foundation's website if it's hosted on GitHub. Thanks! 


<!-- Thank you for submitting a new resource to this list! -->

### Resource description




### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->

- [ x]  I have read and understood the [Contribution Guidelines](htps://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
