### PR TITLE
Update Espruino status & mention block-based programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Contributions are welcome! Not sure how to submit a contribution? Have a look at
 - [CodeMao Kitten Editor](https://ide.codemao.cn) - Block programming platform to create games, includes micro:bit support.
 - [eBlock](https://github.com/distintiva/eBlock) - A Scratch 2 based application (forked from  mBlock 3) to visually code the BBC micro:bit and other devices.
 - [Vittascience](https://vittascience.com/microbit/) - Block programming based on MicroPython for the micro:bit with a built-in simulator.
+- [Espruino JavaScript](https://www.espruino.com/MicroBit) - Contains an in-browser Blocky editor that can program micro:bit wirelessly. Also supports Bluetooth LE functionality.
 
 ##### 🆚 Scratch 2 Extensions
 
@@ -145,7 +146,7 @@ Contributions are welcome! Not sure how to submit a contribution? Have a look at
 	- [MakeCode Windows 10 App](https://www.microsoft.com/store/apps/9pjc7sv48lcx) - Windows 10 application for micro:bit MakeCode.
 	- [MakeCode Offline App](https://makecode.microbit.org/offline-app) - Stand alone offline app (note that MakeCode in the browser also works offline).
 	- [MakeCode Multi Editor](https://makecode.microbit.org/---multi) - Two MakeCode editors side by side to create, modify, and test two micro:bit programs at the same time, great for simulating radio with a transmitter and receiver.
-- [Espruino JavaScript](https://www.espruino.com/MicroBit) - JavaScript interpreter for microcontrollers. It also offers a WebIDE for written code and blocks. The motion sensors from v1.5 of the micro:bit are currently not implemented.
+- [Espruino JavaScript](https://www.espruino.com/MicroBit) - JavaScript interpreter for microcontrollers, supports Bluetooth LE and wireless programming. Also offers a WebIDE for written code and blocks.
 
 ##### 🗿 MakeCode Extensions
 


### PR DESCRIPTION
### Resource description

Espruino now has support for v1.5 accelerometer and magnetometer. There's a note added to the top of https://www.espruino.com/MicroBit to mention you need the newest firmware version to take advantage of it. Also seems worth mentioning Bluetooth LE as I believe it's one of the only things that actually supports proper Bluetooth Low Energy, including the ability to program wirelessly

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

- [*] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [*] I am making an individual pull request for each suggestion
- [*] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [*] The content linked is in English, or it contains an English translation
- [*] I have added the new entry to the bottom of its the category
- [*] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
