### PR TITLE
C++: Add COMPX318 MicroBit Compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 
 - [Micro:Pi](https://github.com/Bottersnike/Micro-Pi) - C/C++ editor for the micro:bit with serial monitor and deploy functionality. Written in Python with an installer (ATM Linux only, but could be manually installed in any OS) that includes all dependencies.
 - [PlatformIO](https://docs.platformio.org/en/latest/boards/nordicnrf51/bbcmicrobit.html) - Embedded IDE with support for the micro:bit using the Arduino or Mbed software stack.
+- [COMPX318 MicroBit Compiler](https://peer-compile.cms.waikato.ac.nz) - Upload a single source file to be compiled online with the DAL C/C++ toolchain and download the resulting hex file.
 
 ##### ©️ C/C++ Libraries
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[COMPX318 MicroBit Compiler](https://peer-compile.cms.waikato.ac.nz) - Upload a single source file to be compiled online with the DAL C/C++ toolchain and download the resulting hex file.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
