### PR TITLE
Python: Add Combining micro:bit with TI calculators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Contributions are welcome! Not sure how to submit a contribution? Have a look at
 - [MicroREPL](https://github.com/ntoll/microrepl) - A REPL client for MicroPython running on the BBC micro:bit.
 - [MicroFs](https://github.com/ntoll/microfs) - Simple command line tool and module for interacting with the limited file system provided by MicroPython on the micro:bit.
 - [Jupyter kernel for the micro:bit](https://github.com/takluyver/ubit_kernel) - Package that allows Jupyter interfaces to run MicroPython code directly on the micro:bit.
+- [Combining micro:bit with TI calculators](https://education.ti.com/en/teachers/microbit) - Connect and programme the BBC micro:bit in Python with multiple TI calculator models.
 
 ### 🗿 JavaScript and MakeCode
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[Combining micro:bit with TI calculators](https://education.ti.com/en/teachers/microbit) - Connect and programme the BBC micro:bit in Python with multiple TI calculator models.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
