### PR TITLE
PXT: Add blehid extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 - [Bluetooth Gamepad](https://github.com/kshoji/pxt-bluetooth-gamepad) - MakeCode extension for BLE HID Gamepad module for micro:bit.
 - [SmartMatrix](https://github.com/Shorts1999/pxt-smartmatrix) - Easily control LED matrices/displays made from WS2812b/NeoPixel controllable RGB LEDs.
 - [Sonic Pi OSC](https://github.com/RBilsland/pxt-sonicpiosc) - Send OpenSound Control (OSC) messages to Sonic Pi from a micro:bit using an ESP8266.
+- [blehid](https://github.com/bsiever/microbit-pxt-blehid) - Set up the micro:bit V2 as Bluetooth HID device, like a keyboard, mouse, or gamepad.
 
 ##### 🗿 Node.js and Browser
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[blehid](https://github.com/bsiever/microbit-pxt-blehid) - Set up the micro:bit V2 as Bluetooth HID device, like a keyboard, mouse, or gamepad.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
