### PR TITLE
Tools: Add midi2ubit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ These languages do not program the micro:bit directly, but can be used to create
 - [micro:bit USB Grapher](https://github.com/bsiever/microbit-usb-grapher) - A web page using WebUSB to graph, manipulate, and save data collected on the micro:bit.
 - [Fab Connect](https://beta.tfabconnect.com/en/) - Online tool & dashboard to bridge multiple micro:bits together via the internet using a WebUSB connection to the browser.
 - [My micro:bit](https://medlight.pl/mymicrobit) - Web app that communicates with the micro:bit via WebUSB or Web Bluetooth. You can control the micro:bit from your computer keyboard, send commands, and analyse sensor data in charts and gauges.
+- [midi2ubit](https://github.com/63rabbits/midi2ubit) - Convert MIDI notes to notes-string for micro:bit. The notes-string can then be played using a MakeCode extention.
 
 
 ## 📱 Mobile Apps


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[midi2ubit](https://github.com/63rabbits/midi2ubit) - Convert MIDI notes to notes-string for micro:bit. The notes-string can then be played using a MakeCode extention.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
