### PR TITLE
Remove outdated MicroRust book

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,6 @@ The following extensions can be added into MakeCode by copying the GitHub URL an
 
 - [Board support crate for micro:bit](https://docs.rs/crate/microbit/) - Contains everything required to get started with the use of Rust to create firmwares for the BBC micro:bit board.
 - [Running Rust code on a BBC micro:bit](https://github.com/SimonSapin/rust-on-bbc-microbit) - Article describing the experience and steps of compiling Rust code for the micro:bit with and without interaction with the runtime DAL.
-- [MicroRust](https://droogmic.github.io/microrust/) - Discover the world of microcontrollers through Rust on the BBC micro:bit.
 - [Rust on the micro:bit 101](https://www.eggers-club.de/blog/2018/05/31/rust-on-the-microbit-101-part-1/) - How to get started using the board support crate and start programming the BBC micro:bit in Rust.
 - [Rust on the BBC micro:bit](https://blog.drogue.io/rust-and-microbit/) - How to get started using Rust and BLE on the micro:bit, exposing temperature data as a Bluetooth Environment Sensing Service, and publishing it to the Drogue Cloud via a Bluetooth gateway.
 - [Tock](https://github.com/tock/tock/blob/master/boards/microbit_v2/README.md) - An embedded operating system designed for running multiple concurrent, mutually distrustful applications on low-memory and low-power microcontrollers, with support for the BBC micro:bit.


### PR DESCRIPTION


<!-- Thank you for submitting a new resource to this list! -->

### Resource description

This book https://droogmic.github.io/microrust/ was adopted and updated by https://docs.rust-embedded.org/discovery/microbit/, so no point in recommending the outdated book first - it is very confusing and people [come](https://github.com/droogmic/microrust/issues/30) and [ask](https://github.com/droogmic/microrust/issues/29) whether that resource is still useful or will be updated.

So, the newest book should be recommended instead.

Ideally, the new book should be placed at the top of the Rust category - since it is fundamental. And recommending various articles first is counter-productive.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [ ] ~I have added the new entry to the bottom of its the category~ N/A
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
