### PR TITLE
2D: Add micro:bit artwork tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ The USB Interface Chip is the microcontroller placed close to the battery connec
 - [micro:bit Fritzing Part](https://github.com/topshed/FritzingParts) - Richard Hayler collection of Fritzing parts contains a model for the micro:bit.
 - [micro:bit-o-matic](https://pycomic.github.io/microbit.html) - Easily create micro:bit illustrations with custom LED matrix messages.
 - [micro:bit SVG](https://github.com/microbit-foundation/microbit-svg) - A detailed SVG (Scalable Vector Graphics) drawing of the BBC micro:bit.
+- [micro:bit artwork tool](https://microbit.org/design-your-microbit/v2/) - Online tool to create a bitmap or vector image of the BBC micro:bit board with custom LED display and micro:bit colour configuration.
 - [MonkMakes micro:bit Diagramming Kit](https://github.com/simonmonk/mm_mb_diagramming_kit) - An SVG file template for drawing BBC micro:bit wiring diagrams using alligator clips.
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a new resource to this list! -->

### Resource description

<!-- Please include a short description of the link here -->
[micro:bit artwork tool](https://microbit.org/design-your-microbit/v2/) - Online tool to create a bitmap or vector image of the BBC micro:bit board with custom LED display and micro:bit colour configuration.

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖

<!-- Please fill in the below checklists to confirm you have followed the guidelines -->
- [x] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [x] I am making an individual pull request for each suggestion
- [x] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [x] The content linked is in English, or it contains an English translation
- [x] I have added the new entry to the bottom of its the category
- [x] I have used the following format:
```
- [Resource Title](link) - Resource short Description (2 lines or less in total)
```
