### PR TITLE
Fixed the grammatical error in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Contributions are welcome! Not sure how to submit a contribution? Have a look at
 - [Espruino JavaScript](https://www.espruino.com/MicroBit) - Contains an in-browser Blocky editor that can program micro:bit wirelessly. Also supports Bluetooth LE functionality.
 - [Tinkercad Circuits](https://www.tinkercad.com/learn/circuits) - Create, code, and simulate electronic designs using common components with the micro:bit or Arduino, [related article](https://blog.tinkercad.com/explore-microbit-with-tinkercad).
 - [OpenBlock](https://openblockcc.github.io/en/) - Block programming with hardware device support, including micro:bit, with code generation, compilation, flashing, and serial connection.
-- [MicroCode](https://microsoft.github.io/microcode/) - MicroCode is a icon-based (minimal text), editor for the micro:bit V2, which can also be used to write programmes directly on the micro:bit with an Arcade Shield. It is suitable for younger learners and users with variable accessibility needs.
+- [MicroCode](https://microsoft.github.io/microcode/) - MicroCode is an icon-based (minimal text), editor for the micro:bit V2, which can also be used to write programmes directly on the micro:bit with an Arcade Shield. It is suitable for younger learners and users with variable accessibility needs.
 
 ##### 🆚 Unofficial Scratch Extensions
 


### PR DESCRIPTION
Changed MicroCode is a icon-based to MicroCode is an icon-based

### By submitting this pull request I confirm I've read and complied with the below requirements 🖖


- [ x ] I have read and understood the [Contribution Guidelines](https://github.com/carlosperate/awesome-microbit/blob/master/contributing.md)
- [ x ]  I am making an individual pull request for each suggestion
- [ x ] I have used the correct spelling and capitalisation for `BBC micro:bit`, `micro:bit`, and `Micro:bit Educational Foundation` (resource title could be excluded if there is a good reason)
- [ x ] The content linked is in English, or it contains an English translation
- [ x ] I have added the new entry to the bottom of its the category
- [ x ] I have used the following format:
```

